### PR TITLE
Include query params into HttpService

### DIFF
--- a/app/src/services/http-service.ts
+++ b/app/src/services/http-service.ts
@@ -71,7 +71,7 @@ export class HttpService {
 
   requestImpl(url:string, method:RequestMethod, opt?: RequestOptionsArgs):Observable<Response>{
     let headers = new Headers();
-    let options: RequestOptions = new BaseRequestOptions();
+    let options: RequestOptionsArgs = new BaseRequestOptions();
     if (!opt) {
       options.url = url;
       options.method =  method;
@@ -81,6 +81,8 @@ export class HttpService {
       options.url = url;
       options.method = method;
       options.body = opt.body;
+      options.params = opt.params;
+      options.search = opt.search;
       options.headers = opt.headers || headers;
       options.withCredentials = false;
     }


### PR DESCRIPTION
Hi Justin, I found a bug that does not affect space finder app, but it affects developers that use space finder as the code base to create a mobile app with AWS.

Bug: Http request is not sending query parameters **(/basepath/endpointname?query=sometext)**

The bug is not related to Angular Http component, problem is that we override `RequestOptions` on `HttpService` component.

I hope you understand that this is an important bug that should be solved.

